### PR TITLE
feat(completion): Move cursor to end of inserted completion

### DIFF
--- a/lua/gemini/completion.lua
+++ b/lua/gemini/completion.lua
@@ -177,6 +177,14 @@ M.insert_completion_result = function()
   local lines = vim.split(context.completion.content, '\n')
   lines[1] = string.sub(first_line, 1, col) .. lines[1]
   vim.api.nvim_buf_set_lines(bufnr, row, row + 1, false, lines)
+
+  if config.get_config({ 'completion', 'move_cursor_end' }) == true then
+    local last_line = lines[#lines]
+    local new_row = row + #lines - 1
+    local new_col = #vim.api.nvim_buf_get_lines(0, new_row - 1, new_row, false)[1]
+    vim.api.nvim_win_set_cursor(0, { new_row, new_col })
+  end
+
   context.completion = nil
 end
 

--- a/lua/gemini/config.lua
+++ b/lua/gemini/config.lua
@@ -86,6 +86,7 @@ local default_completion_config = {
   blacklist_filenames = { '.env' },
   completion_delay = 600,
   insert_result_key = '<S-Tab>',
+  move_cursor_end = false,
   get_system_text = function()
     return "You are a coding AI assistant that autocomplete user's code at a specific cursor location marked by <insert_here></insert_here>."
       .. '\nDo not wrap the code in ```'


### PR DESCRIPTION
This commit introduces a new configuration option `completion.move_cursor_end` that, when enabled, moves the cursor to the end of the last line of the inserted completion result.

The following changes were made:

- Added `move_cursor_end = false` to the default completion configuration in `config.lua`.
- In `completion.lua`, when the `move_cursor_end` option is enabled, the code now calculates the row and column of the last line of the inserted completion, and moves the cursor to that position using `nvim_win_set_cursor`.